### PR TITLE
Sub-module references

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -5,7 +5,6 @@
 - Local function improvements:
     - Allow public use of local functions, or provide a public equivalent.
 - General improvements:
-    - Add support for sub-module references. [ [#14](https://github.com/6XGate/decoration-vuex/issues/14) ]
     - Support, or block, inheriting classes already decorated with `@Module`.
     - Maybe, support open-state access on objects and arrays of a module.
 - Project improvements:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "typings": "dist/types/index.d.ts",
   "scripts": {
     "lint": "eslint src tests rolete.config.js",
+    "fix": "eslint --fix src tests rolete.config.js",
     "dev": "rolete -c dev",
     "prod": "rolete -c prod",
     "coverage": "nyc ava",
@@ -72,8 +73,8 @@
     "@rolete/rolete": "^1.1.0",
     "@rollup/plugin-typescript": "^8.2.0",
     "@types/lodash": "^4.14.168",
-    "@typescript-eslint/eslint-plugin": "^4.17.0",
-    "@typescript-eslint/parser": "^4.17.0",
+    "@typescript-eslint/eslint-plugin": "^4.18.0",
+    "@typescript-eslint/parser": "^4.18.0",
     "ava": "^3.15.0",
     "eslint": "^7.22.0",
     "eslint-plugin-import": "^2.22.1",

--- a/src/details.ts
+++ b/src/details.ts
@@ -45,10 +45,11 @@ export type LocalMember<M extends StoreModule> =
 
 export type ProxyAccess = (...args: unknown[]) => unknown;
 
-type MemberKind = "state"|"getter"|"accessor"|"mutation"|"action"|"watcher"|"local";
+type MemberKind = "state"|"reference"|"getter"|"accessor"|"mutation"|"action"|"watcher"|"local";
 
 export class ModuleDefinition<M extends StoreModule> {
     state = new Set<keyof M>();
+    references = new Map<string|keyof M, StoreModule>();
     getters = new Map<string|keyof M, LocalGetter<M>>();
     setters = new Map<string|keyof M, LocalSetter<M>>();
     accessors = new Map<string|keyof M, LocalAccessor<M>>();

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,12 +2,15 @@ import type { ModuleOptions } from "./options";
 import { makeStaticProxy } from "./proxy/static-proxy";
 import type { StoreModule } from "./store-modules";
 
-function isConstructor(arg: unknown): arg is typeof StoreModule {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type StoreModuleConstructor = new (...args: any[]) => StoreModule;
+
+function isConstructor(arg: unknown): arg is StoreModuleConstructor {
     return typeof arg === "function";
 }
 
 interface StoreModuleDecorator {
-    <M extends typeof StoreModule>(constructor: M): M;
+    <M extends StoreModuleConstructor>(constructor: M): M;
 }
 
 function moduleDecorator(moduleOptions?: ModuleOptions): StoreModuleDecorator {
@@ -24,9 +27,9 @@ function moduleDecorator(moduleOptions?: ModuleOptions): StoreModuleDecorator {
 }
 
 /* eslint-disable @typescript-eslint/naming-convention */
-export function Module<M extends typeof StoreModule>(constructor: M): M;
+export function Module<M extends StoreModuleConstructor>(constructor: M): M;
 export function Module(options?: ModuleOptions): StoreModuleDecorator;
-export function Module(arg?: ModuleOptions|typeof StoreModule): StoreModuleDecorator|typeof StoreModule {
+export function Module(arg?: ModuleOptions|StoreModuleConstructor): StoreModuleDecorator|StoreModuleConstructor {
     return isConstructor(arg) ? moduleDecorator()(arg) : moduleDecorator(arg);
 }
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/src/proxy/factory.ts
+++ b/src/proxy/factory.ts
@@ -31,10 +31,18 @@ class StoreModuleProxyFactory<M extends typeof StoreModule> {
 
         // Register state, which will be needed for openState modules.
         for (const [ key, value ] of Object.entries(instance)) {
-            /* istanbul ignore next */
             if (value instanceof StoreModule) {
-                // TODO: Sub-module referencing.
-                getLogger().warn("Sub-module referencing not implemented.");
+                this.definition.references.set(key as keyof S, value);
+
+                this.definition.members.set(key as keyof S, "reference");
+
+                // Redefine the sub-module property as an immutable property so it cannot be reactive.
+                Object.defineProperty(instance, key, {
+                    configurable: false,
+                    enumerable:   false,
+                    writable:     false,
+                    value,
+                });
             } else {
                 this.definition.state.add(key as keyof S);
 

--- a/src/proxy/static-proxy.ts
+++ b/src/proxy/static-proxy.ts
@@ -1,10 +1,11 @@
+import type { StoreModuleConstructor } from "../module";
 import type { RegisterOptions } from "../options";
 import type { StoreModule } from "../store-modules";
 import { makeProxyFactory } from "./factory";
 
-class StoreModuleStaticHandler<M extends typeof StoreModule> implements ProxyHandler<M> {
-    // eslint-disable-next-line @typescript-eslint/naming-convention,class-methods-use-this
-    construct(Target: M, args: [RegisterOptions]): InstanceType<M> {
+class StoreModuleStaticHandler<M extends StoreModuleConstructor> implements ProxyHandler<M> {
+    // eslint-disable-next-line class-methods-use-this,@typescript-eslint/naming-convention,@typescript-eslint/no-explicit-any
+    construct(Target: M, args: [RegisterOptions, ...any[]]): InstanceType<M> {
         type S = InstanceType<M>;
 
         const instance = new Target(...args) as S;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,9 @@
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+export const hasOwnProperty = Object.prototype.hasOwnProperty.call.bind(Object.prototype.hasOwnProperty) as
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    (target: Object, key: PropertyKey) => boolean;
+
 export function msg(message: string): string {
     return `[decoration-vuex]: ${message}`;
 }

--- a/tests/actions.ts
+++ b/tests/actions.ts
@@ -92,7 +92,7 @@ test.serial("Getting value", async t => {
 test.serial("Setting value in closed state", async t => {
     await t.throwsAsync(
         () => t.context.closed.trySetValue(6),
-        { instanceOf: Error, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
+        { instanceOf: TypeError, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
     );
 
     t.is(t.context.closed.value, await t.context.closed.tryGetValue());

--- a/tests/errors.ts
+++ b/tests/errors.ts
@@ -354,7 +354,7 @@ test("No such property", t => {
         // @ts-expect-error No such property
         goodModule.count = 2;
     }, {
-        instanceOf: ReferenceError,
+        instanceOf: TypeError,
         message:    "[decoration-vuex]: Cannot add or modify property count of store.",
     });
 });

--- a/tests/locals.ts
+++ b/tests/locals.ts
@@ -238,7 +238,7 @@ test.serial("Action accessing value", async t => {
 test.serial("Action mutating value in closed state", async t => {
     await t.throwsAsync(
         () => t.context.closed.trySetValue(8),
-        { instanceOf: Error, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
+        { instanceOf: TypeError, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
     );
     t.is(await t.context.closed.tryGetValue(), 7 * 2);
 });
@@ -288,7 +288,7 @@ test.serial("Action using action to set X", async t => {
 test.serial("Writing through getter", t => {
     t.throws(
         () => { t.is(t.context.closed.badWriting, NaN) },
-        { instanceOf: Error, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
+        { instanceOf: TypeError, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
     );
 });
 
@@ -316,7 +316,7 @@ test.serial("Acting through getter", t => {
 test.serial("Writing through accessor", t => {
     t.throws(
         () => { t.context.closed.failWriting() },
-        { instanceOf: Error, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
+        { instanceOf: TypeError, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
     );
 });
 

--- a/tests/state.ts
+++ b/tests/state.ts
@@ -37,7 +37,7 @@ test("Getting property on closed state", t => {
 test("Setting property on closed state", t => {
     t.throws(
         () => { t.context.closed.value = 7 },
-        { instanceOf: Error, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
+        { instanceOf: TypeError, message: /^\[decoration-vuex\]: Cannot modify the state outside mutations/u },
     );
 
     t.is(t.context.closed.value, 5);

--- a/tests/sub-modules.ts
+++ b/tests/sub-modules.ts
@@ -1,0 +1,132 @@
+import type { TestInterface } from "ava";
+import storeTest from "ava";
+import Vue from "vue";
+import Vuex, { Store } from "vuex";
+import type { RegisterOptions, LoggerEvent } from "../src";
+import { Module, Mutation, ObservableLogger, StoreModule, Watch } from "../src";
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Return type is cannot declarable.
+function makeContext() {
+    Vue.use(Vuex);
+
+    const store = new Store({});
+
+    const logger =  new ObservableLogger();
+
+    @Module
+    class SubModule extends StoreModule {
+        main: MainModule;
+        value = 5;
+
+        constructor(options: RegisterOptions, main: MainModule) {
+            super(options);
+            this.main = main;
+        }
+
+        @Watch("value")
+        // eslint-disable-next-line class-methods-use-this
+        onValueChanged(val: number): void {
+            logger.log(val);
+        }
+
+        @Mutation
+        inc(by: number): void {
+            this.value += by;
+        }
+    }
+
+    @Module({ openState: true })
+    class MainModule extends StoreModule {
+        subModule = new SubModule({ store }, this);
+        value = 6;
+
+        @Watch("value")
+        // eslint-disable-next-line class-methods-use-this
+        onValueChanged(val: number): void {
+            logger.log(val);
+        }
+    }
+
+    return {
+        store,
+        logger,
+        main: new MainModule({ store }),
+    };
+}
+
+const test = storeTest as TestInterface<ReturnType<typeof makeContext>>;
+
+test.before(t => {
+    t.context = makeContext();
+});
+
+test("submodule descriptor", t => {
+    const descriptor = Object.getOwnPropertyDescriptor(t.context.main, "subModule");
+    const subModule = t.context.main.subModule;
+
+    t.truthy(descriptor);
+    if (descriptor) {
+        t.false(descriptor.configurable);
+        t.false(descriptor.enumerable);
+        t.false(descriptor.writable);
+        t.is(descriptor.value, subModule);
+    }
+
+    t.throws(() => {
+        // @ts-expect-error Trying to reassign this to test immutability
+        t.context.main.subModule = 5;
+    }, {
+        instanceOf: TypeError,
+        message:    "[decoration-vuex]: Sub-module reference subModule is immutable",
+    });
+
+    t.is(t.context.main.subModule, subModule);
+
+    t.plan(7);
+});
+
+test("main descriptor, cyclic references", t => {
+    const descriptor = Object.getOwnPropertyDescriptor(t.context.main.subModule, "main");
+    const main = t.context.main.subModule.main;
+
+    t.truthy(descriptor);
+    if (descriptor) {
+        t.false(descriptor.configurable);
+        t.false(descriptor.enumerable);
+        t.false(descriptor.writable);
+        t.is(descriptor.value, main);
+    }
+
+    t.throws(() => {
+        // @ts-expect-error Trying to reassign this to test immutability
+        t.context.main.subModule.main = 5;
+    }, {
+        instanceOf: TypeError,
+        message:    "[decoration-vuex]: Sub-module reference main is immutable",
+    });
+
+    t.is(t.context.main.subModule.main, main);
+
+    t.plan(7);
+});
+
+test("read heir state", t => new Promise(resolve => {
+    t.is(t.context.main.value, 6);
+    t.is(t.context.main.subModule.value, 5);
+    t.is(t.context.main.subModule.main.value, 6);
+
+
+    const onLog = (log: LoggerEvent): void => {
+        t.is(log.name, "log");
+        t.deepEqual(log.args["...data"], [7]);
+        t.context.logger.off("log", onLog);
+
+        resolve();
+    };
+
+    t.context.logger.on("log", onLog);
+
+    t.context.main.subModule.inc(2);
+
+    t.is(t.context.main.subModule.value, 7);
+}));


### PR DESCRIPTION
- Added support for sub-module references, closing #14 
- Pre-bound the hasOwnProperty method.
- Changed the set trap errors to TypeError.
- Relaxed the constructor type for the module decorator and static proxy.
- Added a ESLint fix command to the npm scripts.